### PR TITLE
feat: add GestFarmacy API with in-memory repositories

### DIFF
--- a/GestFarmacy.Api.sln
+++ b/GestFarmacy.Api.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GestFarmacy.Api", "GestFarmacy.Api\GestFarmacy.Api.csproj", "{D2C1C53E-34F4-4B67-93AA-DF44E745D0D0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GestFarmacy.Tests", "GestFarmacy.Tests\GestFarmacy.Tests.csproj", "{E8146D4B-0CB9-4A20-8C5C-EB1ABFB86C47}"
+EndProject
+Global
+  GlobalSection(SolutionConfigurationPlatforms) = preSolution
+    Debug|Any CPU = Debug|Any CPU
+    Release|Any CPU = Release|Any CPU
+  EndGlobalSection
+  GlobalSection(ProjectConfigurationPlatforms) = postSolution
+    {D2C1C53E-34F4-4B67-93AA-DF44E745D0D0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+    {D2C1C53E-34F4-4B67-93AA-DF44E745D0D0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+    {D2C1C53E-34F4-4B67-93AA-DF44E745D0D0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+    {D2C1C53E-34F4-4B67-93AA-DF44E745D0D0}.Release|Any CPU.Build.0 = Release|Any CPU
+    {E8146D4B-0CB9-4A20-8C5C-EB1ABFB86C47}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+    {E8146D4B-0CB9-4A20-8C5C-EB1ABFB86C47}.Debug|Any CPU.Build.0 = Debug|Any CPU
+    {E8146D4B-0CB9-4A20-8C5C-EB1ABFB86C47}.Release|Any CPU.ActiveCfg = Release|Any CPU
+    {E8146D4B-0CB9-4A20-8C5C-EB1ABFB86C47}.Release|Any CPU.Build.0 = Release|Any CPU
+  EndGlobalSection
+EndGlobal

--- a/GestFarmacy.Api/Controllers/CustomersController.cs
+++ b/GestFarmacy.Api/Controllers/CustomersController.cs
@@ -1,0 +1,67 @@
+using AutoMapper;
+using GestFarmacy.Api.Domain.Entities;
+using GestFarmacy.Api.Domain.Interfaces.Services;
+using GestFarmacy.Api.DTOs;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GestFarmacy.Api.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class CustomersController : ControllerBase
+    {
+        private readonly ICustomerService _service;
+        private readonly IMapper _mapper;
+
+        public CustomersController(ICustomerService service, IMapper mapper)
+        {
+            _service = service;
+            _mapper = mapper;
+        }
+
+        [HttpGet]
+        public ActionResult<IEnumerable<CustomerResponse>> Get()
+        {
+            var customers = _service.GetAll();
+            return Ok(_mapper.Map<IEnumerable<CustomerResponse>>(customers));
+        }
+
+        [HttpGet("{id}")]
+        public ActionResult<CustomerResponse> Get(Guid id)
+        {
+            var customer = _service.GetById(id);
+            return Ok(_mapper.Map<CustomerResponse>(customer));
+        }
+
+        [HttpGet("search")]
+        public ActionResult<IEnumerable<CustomerResponse>> Search([FromQuery] string name)
+        {
+            var customers = _service.Search(name);
+            return Ok(_mapper.Map<IEnumerable<CustomerResponse>>(customers));
+        }
+
+        [HttpPost]
+        public ActionResult<CustomerResponse> Post(CustomerRequest request)
+        {
+            var customer = new Customer(Guid.NewGuid(), request.Name, request.Email);
+            var created = _service.Create(customer);
+            var response = _mapper.Map<CustomerResponse>(created);
+            return CreatedAtAction(nameof(Get), new { id = response.Id }, response);
+        }
+
+        [HttpPut("{id}")]
+        public IActionResult Put(Guid id, CustomerRequest request)
+        {
+            var customer = new Customer(id, request.Name, request.Email);
+            _service.Update(customer);
+            return NoContent();
+        }
+
+        [HttpDelete("{id}")]
+        public IActionResult Delete(Guid id)
+        {
+            _service.Delete(id);
+            return NoContent();
+        }
+    }
+}

--- a/GestFarmacy.Api/Controllers/ProductsController.cs
+++ b/GestFarmacy.Api/Controllers/ProductsController.cs
@@ -1,0 +1,67 @@
+using AutoMapper;
+using GestFarmacy.Api.Domain.Entities;
+using GestFarmacy.Api.Domain.Interfaces.Services;
+using GestFarmacy.Api.DTOs;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GestFarmacy.Api.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class ProductsController : ControllerBase
+    {
+        private readonly IProductService _service;
+        private readonly IMapper _mapper;
+
+        public ProductsController(IProductService service, IMapper mapper)
+        {
+            _service = service;
+            _mapper = mapper;
+        }
+
+        [HttpGet]
+        public ActionResult<IEnumerable<ProductResponse>> Get()
+        {
+            var products = _service.GetAll();
+            return Ok(_mapper.Map<IEnumerable<ProductResponse>>(products));
+        }
+
+        [HttpGet("{id}")]
+        public ActionResult<ProductResponse> Get(Guid id)
+        {
+            var product = _service.GetById(id);
+            return Ok(_mapper.Map<ProductResponse>(product));
+        }
+
+        [HttpGet("search")]
+        public ActionResult<IEnumerable<ProductResponse>> Search([FromQuery] string name)
+        {
+            var products = _service.Search(name);
+            return Ok(_mapper.Map<IEnumerable<ProductResponse>>(products));
+        }
+
+        [HttpPost]
+        public ActionResult<ProductResponse> Post(ProductRequest request)
+        {
+            var product = new Product(Guid.NewGuid(), request.Name, request.Price, request.Stock);
+            var created = _service.Create(product);
+            var response = _mapper.Map<ProductResponse>(created);
+            return CreatedAtAction(nameof(Get), new { id = response.Id }, response);
+        }
+
+        [HttpPut("{id}")]
+        public IActionResult Put(Guid id, ProductRequest request)
+        {
+            var product = new Product(id, request.Name, request.Price, request.Stock);
+            _service.Update(product);
+            return NoContent();
+        }
+
+        [HttpDelete("{id}")]
+        public IActionResult Delete(Guid id)
+        {
+            _service.Delete(id);
+            return NoContent();
+        }
+    }
+}

--- a/GestFarmacy.Api/Controllers/SalesController.cs
+++ b/GestFarmacy.Api/Controllers/SalesController.cs
@@ -1,0 +1,59 @@
+using AutoMapper;
+using GestFarmacy.Api.Domain.Entities;
+using GestFarmacy.Api.Domain.Interfaces.Services;
+using GestFarmacy.Api.DTOs;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GestFarmacy.Api.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class SalesController : ControllerBase
+    {
+        private readonly ISaleService _service;
+        private readonly IMapper _mapper;
+
+        public SalesController(ISaleService service, IMapper mapper)
+        {
+            _service = service;
+            _mapper = mapper;
+        }
+
+        [HttpGet]
+        public ActionResult<IEnumerable<SaleResponse>> Get()
+        {
+            var sales = _service.GetAll();
+            return Ok(_mapper.Map<IEnumerable<SaleResponse>>(sales));
+        }
+
+        [HttpGet("{id}")]
+        public ActionResult<SaleResponse> Get(Guid id)
+        {
+            var sale = _service.GetById(id);
+            return Ok(_mapper.Map<SaleResponse>(sale));
+        }
+
+        [HttpGet("customer/{customerId}")]
+        public ActionResult<IEnumerable<SaleResponse>> GetByCustomer(Guid customerId)
+        {
+            var sales = _service.GetByCustomer(customerId);
+            return Ok(_mapper.Map<IEnumerable<SaleResponse>>(sales));
+        }
+
+        [HttpPost]
+        public ActionResult<SaleResponse> Post(SaleRequest request)
+        {
+            var sale = new Sale(Guid.NewGuid(), request.ProductId, request.CustomerId, request.Quantity, DateTime.UtcNow);
+            var created = _service.Create(sale);
+            var response = _mapper.Map<SaleResponse>(created);
+            return CreatedAtAction(nameof(Get), new { id = response.Id }, response);
+        }
+
+        [HttpDelete("{id}")]
+        public IActionResult Delete(Guid id)
+        {
+            _service.Delete(id);
+            return NoContent();
+        }
+    }
+}

--- a/GestFarmacy.Api/DTOs/CustomerRequest.cs
+++ b/GestFarmacy.Api/DTOs/CustomerRequest.cs
@@ -1,0 +1,11 @@
+namespace GestFarmacy.Api.DTOs
+{
+    /// <summary>
+    /// DTO used to create or update a customer.
+    /// </summary>
+    public class CustomerRequest
+    {
+        public string Name { get; set; } = string.Empty;
+        public string Email { get; set; } = string.Empty;
+    }
+}

--- a/GestFarmacy.Api/DTOs/CustomerResponse.cs
+++ b/GestFarmacy.Api/DTOs/CustomerResponse.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace GestFarmacy.Api.DTOs
+{
+    /// <summary>
+    /// DTO returned when querying a customer.
+    /// </summary>
+    public class CustomerResponse
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string Email { get; set; } = string.Empty;
+    }
+}

--- a/GestFarmacy.Api/DTOs/ProductRequest.cs
+++ b/GestFarmacy.Api/DTOs/ProductRequest.cs
@@ -1,0 +1,12 @@
+namespace GestFarmacy.Api.DTOs
+{
+    /// <summary>
+    /// DTO used to create or update a product.
+    /// </summary>
+    public class ProductRequest
+    {
+        public string Name { get; set; } = string.Empty;
+        public decimal Price { get; set; }
+        public int Stock { get; set; }
+    }
+}

--- a/GestFarmacy.Api/DTOs/ProductResponse.cs
+++ b/GestFarmacy.Api/DTOs/ProductResponse.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace GestFarmacy.Api.DTOs
+{
+    /// <summary>
+    /// DTO returned when querying a product.
+    /// </summary>
+    public class ProductResponse
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public decimal Price { get; set; }
+        public int Stock { get; set; }
+    }
+}

--- a/GestFarmacy.Api/DTOs/SaleRequest.cs
+++ b/GestFarmacy.Api/DTOs/SaleRequest.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace GestFarmacy.Api.DTOs
+{
+    /// <summary>
+    /// DTO used to create a sale.
+    /// </summary>
+    public class SaleRequest
+    {
+        public Guid ProductId { get; set; }
+        public Guid CustomerId { get; set; }
+        public int Quantity { get; set; }
+    }
+}

--- a/GestFarmacy.Api/DTOs/SaleResponse.cs
+++ b/GestFarmacy.Api/DTOs/SaleResponse.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace GestFarmacy.Api.DTOs
+{
+    /// <summary>
+    /// DTO returned when querying a sale.
+    /// </summary>
+    public class SaleResponse
+    {
+        public Guid Id { get; set; }
+        public Guid ProductId { get; set; }
+        public Guid CustomerId { get; set; }
+        public int Quantity { get; set; }
+        public DateTime Date { get; set; }
+    }
+}

--- a/GestFarmacy.Api/Domain/Entities/Customer.cs
+++ b/GestFarmacy.Api/Domain/Entities/Customer.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace GestFarmacy.Api.Domain.Entities
+{
+    /// <summary>
+    /// Represents a client of the pharmacy.
+    /// </summary>
+    public class Customer
+    {
+        public Guid Id { get; private set; }
+        public string Name { get; private set; }
+        public string Email { get; private set; }
+
+        public Customer(Guid id, string name, string email)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                throw new ArgumentException("Name cannot be empty", nameof(name));
+            if (!Regex.IsMatch(email, @"^[^@\s]+@[^@\s]+\.[^@\s]+$"))
+                throw new ArgumentException("Email format is invalid", nameof(email));
+
+            Id = id;
+            Name = name;
+            Email = email;
+        }
+    }
+}

--- a/GestFarmacy.Api/Domain/Entities/Product.cs
+++ b/GestFarmacy.Api/Domain/Entities/Product.cs
@@ -1,0 +1,37 @@
+using System;
+
+namespace GestFarmacy.Api.Domain.Entities
+{
+    /// <summary>
+    /// Represents a product sold in the pharmacy.
+    /// </summary>
+    public class Product
+    {
+        public Guid Id { get; private set; }
+        public string Name { get; private set; }
+        public decimal Price { get; private set; }
+        public int Stock { get; private set; }
+
+        public Product(Guid id, string name, decimal price, int stock)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                throw new ArgumentException("Name cannot be empty", nameof(name));
+            if (price < 0)
+                throw new ArgumentException("Price must be positive", nameof(price));
+            if (stock < 0)
+                throw new ArgumentException("Stock must be positive", nameof(stock));
+
+            Id = id;
+            Name = name;
+            Price = price;
+            Stock = stock;
+        }
+
+        public void UpdateStock(int amount)
+        {
+            if (amount < 0)
+                throw new ArgumentException("Amount must be positive", nameof(amount));
+            Stock = amount;
+        }
+    }
+}

--- a/GestFarmacy.Api/Domain/Entities/Sale.cs
+++ b/GestFarmacy.Api/Domain/Entities/Sale.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace GestFarmacy.Api.Domain.Entities
+{
+    /// <summary>
+    /// Represents a sale transaction.
+    /// </summary>
+    public class Sale
+    {
+        public Guid Id { get; private set; }
+        public Guid ProductId { get; private set; }
+        public Guid CustomerId { get; private set; }
+        public int Quantity { get; private set; }
+        public DateTime Date { get; private set; }
+
+        public Sale(Guid id, Guid productId, Guid customerId, int quantity, DateTime date)
+        {
+            if (quantity <= 0)
+                throw new ArgumentException("Quantity must be greater than zero", nameof(quantity));
+
+            Id = id;
+            ProductId = productId;
+            CustomerId = customerId;
+            Quantity = quantity;
+            Date = date;
+        }
+    }
+}

--- a/GestFarmacy.Api/Domain/Interfaces/Repositories/ICustomerRepository.cs
+++ b/GestFarmacy.Api/Domain/Interfaces/Repositories/ICustomerRepository.cs
@@ -1,0 +1,14 @@
+using GestFarmacy.Api.Domain.Entities;
+
+namespace GestFarmacy.Api.Domain.Interfaces.Repositories
+{
+    public interface ICustomerRepository
+    {
+        IEnumerable<Customer> GetAll();
+        Customer? GetById(Guid id);
+        IEnumerable<Customer> SearchByName(string name);
+        void Add(Customer customer);
+        void Update(Customer customer);
+        void Remove(Guid id);
+    }
+}

--- a/GestFarmacy.Api/Domain/Interfaces/Repositories/IProductRepository.cs
+++ b/GestFarmacy.Api/Domain/Interfaces/Repositories/IProductRepository.cs
@@ -1,0 +1,14 @@
+using GestFarmacy.Api.Domain.Entities;
+
+namespace GestFarmacy.Api.Domain.Interfaces.Repositories
+{
+    public interface IProductRepository
+    {
+        IEnumerable<Product> GetAll();
+        Product? GetById(Guid id);
+        IEnumerable<Product> SearchByName(string name);
+        void Add(Product product);
+        void Update(Product product);
+        void Remove(Guid id);
+    }
+}

--- a/GestFarmacy.Api/Domain/Interfaces/Repositories/ISaleRepository.cs
+++ b/GestFarmacy.Api/Domain/Interfaces/Repositories/ISaleRepository.cs
@@ -1,0 +1,13 @@
+using GestFarmacy.Api.Domain.Entities;
+
+namespace GestFarmacy.Api.Domain.Interfaces.Repositories
+{
+    public interface ISaleRepository
+    {
+        IEnumerable<Sale> GetAll();
+        Sale? GetById(Guid id);
+        IEnumerable<Sale> GetByCustomer(Guid customerId);
+        void Add(Sale sale);
+        void Remove(Guid id);
+    }
+}

--- a/GestFarmacy.Api/Domain/Interfaces/Services/ICustomerService.cs
+++ b/GestFarmacy.Api/Domain/Interfaces/Services/ICustomerService.cs
@@ -1,0 +1,14 @@
+using GestFarmacy.Api.Domain.Entities;
+
+namespace GestFarmacy.Api.Domain.Interfaces.Services
+{
+    public interface ICustomerService
+    {
+        IEnumerable<Customer> GetAll();
+        Customer GetById(Guid id);
+        IEnumerable<Customer> Search(string name);
+        Customer Create(Customer customer);
+        void Update(Customer customer);
+        void Delete(Guid id);
+    }
+}

--- a/GestFarmacy.Api/Domain/Interfaces/Services/IProductService.cs
+++ b/GestFarmacy.Api/Domain/Interfaces/Services/IProductService.cs
@@ -1,0 +1,14 @@
+using GestFarmacy.Api.Domain.Entities;
+
+namespace GestFarmacy.Api.Domain.Interfaces.Services
+{
+    public interface IProductService
+    {
+        IEnumerable<Product> GetAll();
+        Product GetById(Guid id);
+        IEnumerable<Product> Search(string name);
+        Product Create(Product product);
+        void Update(Product product);
+        void Delete(Guid id);
+    }
+}

--- a/GestFarmacy.Api/Domain/Interfaces/Services/ISaleService.cs
+++ b/GestFarmacy.Api/Domain/Interfaces/Services/ISaleService.cs
@@ -1,0 +1,13 @@
+using GestFarmacy.Api.Domain.Entities;
+
+namespace GestFarmacy.Api.Domain.Interfaces.Services
+{
+    public interface ISaleService
+    {
+        IEnumerable<Sale> GetAll();
+        Sale GetById(Guid id);
+        IEnumerable<Sale> GetByCustomer(Guid customerId);
+        Sale Create(Sale sale);
+        void Delete(Guid id);
+    }
+}

--- a/GestFarmacy.Api/GestFarmacy.Api.csproj
+++ b/GestFarmacy.Api/GestFarmacy.Api.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+  </ItemGroup>
+</Project>

--- a/GestFarmacy.Api/Mapping/MappingProfile.cs
+++ b/GestFarmacy.Api/Mapping/MappingProfile.cs
@@ -1,0 +1,19 @@
+using AutoMapper;
+using GestFarmacy.Api.Domain.Entities;
+using GestFarmacy.Api.DTOs;
+
+namespace GestFarmacy.Api.Mapping
+{
+    /// <summary>
+    /// AutoMapper profile configuration.
+    /// </summary>
+    public class MappingProfile : Profile
+    {
+        public MappingProfile()
+        {
+            CreateMap<Product, ProductResponse>().ReverseMap();
+            CreateMap<Customer, CustomerResponse>().ReverseMap();
+            CreateMap<Sale, SaleResponse>().ReverseMap();
+        }
+    }
+}

--- a/GestFarmacy.Api/Program.cs
+++ b/GestFarmacy.Api/Program.cs
@@ -1,0 +1,42 @@
+using AutoMapper;
+using GestFarmacy.Api.Domain.Interfaces.Repositories;
+using GestFarmacy.Api.Domain.Interfaces.Services;
+using GestFarmacy.Api.Mapping;
+using GestFarmacy.Api.Repositories;
+using GestFarmacy.Api.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+// AutoMapper configuration
+builder.Services.AddAutoMapper(typeof(MappingProfile));
+
+// Dependency Injection for repositories and services
+builder.Services.AddSingleton<IProductRepository, ProductRepository>();
+builder.Services.AddSingleton<ICustomerRepository, CustomerRepository>();
+builder.Services.AddSingleton<ISaleRepository, SaleRepository>();
+
+builder.Services.AddScoped<IProductService, ProductService>();
+builder.Services.AddScoped<ICustomerService, CustomerService>();
+builder.Services.AddScoped<ISaleService, SaleService>();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();

--- a/GestFarmacy.Api/Properties/launchSettings.json
+++ b/GestFarmacy.Api/Properties/launchSettings.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "GestFarmacy.Api": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/GestFarmacy.Api/Repositories/CustomerRepository.cs
+++ b/GestFarmacy.Api/Repositories/CustomerRepository.cs
@@ -1,0 +1,43 @@
+using GestFarmacy.Api.Domain.Entities;
+using GestFarmacy.Api.Domain.Interfaces.Repositories;
+
+namespace GestFarmacy.Api.Repositories
+{
+    /// <summary>
+    /// In-memory implementation of customer repository.
+    /// </summary>
+    public class CustomerRepository : ICustomerRepository
+    {
+        private static readonly List<Customer> _customers = new()
+        {
+            new Customer(Guid.NewGuid(), "John Doe", "john@example.com"),
+            new Customer(Guid.NewGuid(), "Jane Smith", "jane@example.com")
+        };
+
+        public IEnumerable<Customer> GetAll() => _customers;
+
+        public Customer? GetById(Guid id) => _customers.FirstOrDefault(c => c.Id == id);
+
+        public IEnumerable<Customer> SearchByName(string name) =>
+            _customers.Where(c => c.Name.Contains(name, StringComparison.OrdinalIgnoreCase));
+
+        public void Add(Customer customer) => _customers.Add(customer);
+
+        public void Update(Customer customer)
+        {
+            var existing = GetById(customer.Id);
+            if (existing != null)
+            {
+                _customers.Remove(existing);
+                _customers.Add(customer);
+            }
+        }
+
+        public void Remove(Guid id)
+        {
+            var customer = GetById(id);
+            if (customer != null)
+                _customers.Remove(customer);
+        }
+    }
+}

--- a/GestFarmacy.Api/Repositories/ProductRepository.cs
+++ b/GestFarmacy.Api/Repositories/ProductRepository.cs
@@ -1,0 +1,43 @@
+using GestFarmacy.Api.Domain.Entities;
+using GestFarmacy.Api.Domain.Interfaces.Repositories;
+
+namespace GestFarmacy.Api.Repositories
+{
+    /// <summary>
+    /// In-memory implementation of product repository.
+    /// </summary>
+    public class ProductRepository : IProductRepository
+    {
+        private static readonly List<Product> _products = new()
+        {
+            new Product(Guid.NewGuid(), "Aspirin", 10m, 100),
+            new Product(Guid.NewGuid(), "Ibuprofen", 15m, 200)
+        };
+
+        public IEnumerable<Product> GetAll() => _products;
+
+        public Product? GetById(Guid id) => _products.FirstOrDefault(p => p.Id == id);
+
+        public IEnumerable<Product> SearchByName(string name) =>
+            _products.Where(p => p.Name.Contains(name, StringComparison.OrdinalIgnoreCase));
+
+        public void Add(Product product) => _products.Add(product);
+
+        public void Update(Product product)
+        {
+            var existing = GetById(product.Id);
+            if (existing != null)
+            {
+                _products.Remove(existing);
+                _products.Add(product);
+            }
+        }
+
+        public void Remove(Guid id)
+        {
+            var product = GetById(id);
+            if (product != null)
+                _products.Remove(product);
+        }
+    }
+}

--- a/GestFarmacy.Api/Repositories/SaleRepository.cs
+++ b/GestFarmacy.Api/Repositories/SaleRepository.cs
@@ -1,0 +1,29 @@
+using GestFarmacy.Api.Domain.Entities;
+using GestFarmacy.Api.Domain.Interfaces.Repositories;
+
+namespace GestFarmacy.Api.Repositories
+{
+    /// <summary>
+    /// In-memory implementation of sale repository.
+    /// </summary>
+    public class SaleRepository : ISaleRepository
+    {
+        private static readonly List<Sale> _sales = new();
+
+        public IEnumerable<Sale> GetAll() => _sales;
+
+        public Sale? GetById(Guid id) => _sales.FirstOrDefault(s => s.Id == id);
+
+        public IEnumerable<Sale> GetByCustomer(Guid customerId) =>
+            _sales.Where(s => s.CustomerId == customerId);
+
+        public void Add(Sale sale) => _sales.Add(sale);
+
+        public void Remove(Guid id)
+        {
+            var sale = GetById(id);
+            if (sale != null)
+                _sales.Remove(sale);
+        }
+    }
+}

--- a/GestFarmacy.Api/Services/CustomerService.cs
+++ b/GestFarmacy.Api/Services/CustomerService.cs
@@ -1,0 +1,41 @@
+using GestFarmacy.Api.Domain.Entities;
+using GestFarmacy.Api.Domain.Interfaces.Repositories;
+using GestFarmacy.Api.Domain.Interfaces.Services;
+
+namespace GestFarmacy.Api.Services
+{
+    /// <summary>
+    /// Business logic for customers.
+    /// </summary>
+    public class CustomerService : ICustomerService
+    {
+        private readonly ICustomerRepository _repository;
+
+        public CustomerService(ICustomerRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public Customer Create(Customer customer)
+        {
+            _repository.Add(customer);
+            return customer;
+        }
+
+        public void Delete(Guid id) => _repository.Remove(id);
+
+        public IEnumerable<Customer> GetAll() => _repository.GetAll();
+
+        public Customer GetById(Guid id)
+        {
+            var customer = _repository.GetById(id);
+            if (customer == null)
+                throw new KeyNotFoundException("Customer not found");
+            return customer;
+        }
+
+        public IEnumerable<Customer> Search(string name) => _repository.SearchByName(name);
+
+        public void Update(Customer customer) => _repository.Update(customer);
+    }
+}

--- a/GestFarmacy.Api/Services/ProductService.cs
+++ b/GestFarmacy.Api/Services/ProductService.cs
@@ -1,0 +1,41 @@
+using GestFarmacy.Api.Domain.Entities;
+using GestFarmacy.Api.Domain.Interfaces.Repositories;
+using GestFarmacy.Api.Domain.Interfaces.Services;
+
+namespace GestFarmacy.Api.Services
+{
+    /// <summary>
+    /// Business logic for products.
+    /// </summary>
+    public class ProductService : IProductService
+    {
+        private readonly IProductRepository _repository;
+
+        public ProductService(IProductRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public Product Create(Product product)
+        {
+            _repository.Add(product);
+            return product;
+        }
+
+        public void Delete(Guid id) => _repository.Remove(id);
+
+        public IEnumerable<Product> GetAll() => _repository.GetAll();
+
+        public Product GetById(Guid id)
+        {
+            var product = _repository.GetById(id);
+            if (product == null)
+                throw new KeyNotFoundException("Product not found");
+            return product;
+        }
+
+        public IEnumerable<Product> Search(string name) => _repository.SearchByName(name);
+
+        public void Update(Product product) => _repository.Update(product);
+    }
+}

--- a/GestFarmacy.Api/Services/SaleService.cs
+++ b/GestFarmacy.Api/Services/SaleService.cs
@@ -1,0 +1,39 @@
+using GestFarmacy.Api.Domain.Entities;
+using GestFarmacy.Api.Domain.Interfaces.Repositories;
+using GestFarmacy.Api.Domain.Interfaces.Services;
+
+namespace GestFarmacy.Api.Services
+{
+    /// <summary>
+    /// Business logic for sales.
+    /// </summary>
+    public class SaleService : ISaleService
+    {
+        private readonly ISaleRepository _repository;
+
+        public SaleService(ISaleRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public Sale Create(Sale sale)
+        {
+            _repository.Add(sale);
+            return sale;
+        }
+
+        public void Delete(Guid id) => _repository.Remove(id);
+
+        public IEnumerable<Sale> GetAll() => _repository.GetAll();
+
+        public Sale GetById(Guid id)
+        {
+            var sale = _repository.GetById(id);
+            if (sale == null)
+                throw new KeyNotFoundException("Sale not found");
+            return sale;
+        }
+
+        public IEnumerable<Sale> GetByCustomer(Guid customerId) => _repository.GetByCustomer(customerId);
+    }
+}

--- a/GestFarmacy.Api/appsettings.json
+++ b/GestFarmacy.Api/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/GestFarmacy.Tests/GestFarmacy.Tests.csproj
+++ b/GestFarmacy.Tests/GestFarmacy.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\GestFarmacy.Api\GestFarmacy.Api.csproj" />
+  </ItemGroup>
+</Project>

--- a/GestFarmacy.Tests/ProductServiceTests.cs
+++ b/GestFarmacy.Tests/ProductServiceTests.cs
@@ -1,0 +1,28 @@
+using GestFarmacy.Api.Domain.Entities;
+using GestFarmacy.Api.Domain.Interfaces.Repositories;
+using GestFarmacy.Api.Services;
+using Moq;
+using Xunit;
+
+namespace GestFarmacy.Tests
+{
+    public class ProductServiceTests
+    {
+        [Fact]
+        public void GetById_ProductExists_ReturnsProduct()
+        {
+            // Arrange
+            var id = Guid.NewGuid();
+            var product = new Product(id, "Test", 5m, 1);
+            var repoMock = new Mock<IProductRepository>();
+            repoMock.Setup(r => r.GetById(id)).Returns(product);
+            var service = new ProductService(repoMock.Object);
+
+            // Act
+            var result = service.GetById(id);
+
+            // Assert
+            Assert.Equal(product, result);
+        }
+    }
+}

--- a/GestFarmacy.Tests/ProductsControllerTests.cs
+++ b/GestFarmacy.Tests/ProductsControllerTests.cs
@@ -1,0 +1,37 @@
+using AutoMapper;
+using GestFarmacy.Api.Controllers;
+using GestFarmacy.Api.Domain.Entities;
+using GestFarmacy.Api.Domain.Interfaces.Services;
+using GestFarmacy.Api.Mapping;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+
+namespace GestFarmacy.Tests
+{
+    public class ProductsControllerTests
+    {
+        private readonly IMapper _mapper;
+
+        public ProductsControllerTests()
+        {
+            var config = new MapperConfiguration(cfg => cfg.AddProfile<MappingProfile>());
+            _mapper = config.CreateMapper();
+        }
+
+        [Fact]
+        public void Get_ReturnsOk()
+        {
+            // Arrange
+            var serviceMock = new Mock<IProductService>();
+            serviceMock.Setup(s => s.GetAll()).Returns(new List<Product>());
+            var controller = new ProductsController(serviceMock.Object, _mapper);
+
+            // Act
+            var result = controller.Get();
+
+            // Assert
+            Assert.IsType<OkObjectResult>(result.Result);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add .NET 6 Web API project with products, customers and sales
- implement services, repositories and AutoMapper mappings
- include xUnit tests for service and controller

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6aabd330832c8ad80c3f0de36e6e